### PR TITLE
Carrierwaveでアップロード時にファイル名の長さチェックができるように拡張

### DIFF
--- a/bizside_test_app/app/models/application_record.rb
+++ b/bizside_test_app/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/bizside_test_app/app/models/attachment_file.rb
+++ b/bizside_test_app/app/models/attachment_file.rb
@@ -1,0 +1,5 @@
+class AttachmentFile < ApplicationRecord
+  mount_uploader :file, AttachmentFileUploader
+
+  validates :original_filename, length: {maximum: 63}
+end

--- a/bizside_test_app/app/models/ip_address.rb
+++ b/bizside_test_app/app/models/ip_address.rb
@@ -1,7 +1,7 @@
 # IpAddressValidatorのテスト用モデル
 require 'bizside/validations'
 
-class IpAddress < ActiveRecord::Base
+class IpAddress < ApplicationRecord
   validates :ip_address_v4, ip_address: true
   validates :ip_address_cidr, ip_address: {cidr: true}
 end

--- a/bizside_test_app/app/models/url.rb
+++ b/bizside_test_app/app/models/url.rb
@@ -1,7 +1,7 @@
 # UrlValidatorのテスト用モデル
 require 'bizside/validations'
 
-class Url < ActiveRecord::Base
+class Url < ApplicationRecord
   validates :url, url: true
   validates :url_without_schema, url: {with_schema: false}
 end

--- a/bizside_test_app/app/uploaders/attachment_file_uploader.rb
+++ b/bizside_test_app/app/uploaders/attachment_file_uploader.rb
@@ -1,0 +1,5 @@
+require 'bizside/file_uploader'
+
+class AttachmentFileUploader < Bizside::FileUploader
+
+end

--- a/bizside_test_app/config/bizside.yml
+++ b/bizside_test_app/config/bizside.yml
@@ -27,6 +27,7 @@ default: &default
   warning_validation:
     enabled: true
   file_uploader:
+    ignore_long_filename_error: false #originai_filename をモデルで定義している場合は、true に設定し、ファイル名の長さチェックを行うことが望ましい。デフォルトは false
     #extension_whitelist_enabled: （Bizsideのホワイトリストをする場合true。falseはデフォルトで拡張子制限なし。）
     #api_enabled: (APIでポータルの拡張子一覧と連携するかどうか。falseのときはファイルから読み込まれる。)
     #extensions_file_path: （アップロード可能拡張子一覧のYAMLファイルのパス。指定なしの場合はbizside.gem内のデフォルトを使用）

--- a/bizside_test_app/db/migrate/20180419014509_create_ip_addresses.rb
+++ b/bizside_test_app/db/migrate/20180419014509_create_ip_addresses.rb
@@ -1,4 +1,4 @@
-class CreateIpAddresses < ActiveRecord::Migration
+class CreateIpAddresses < ActiveRecord::Migration[5.2]
   def change
     create_table :ip_addresses do |t|
       t.string :ip_address_v4

--- a/bizside_test_app/db/migrate/20180614071450_create_urls.rb
+++ b/bizside_test_app/db/migrate/20180614071450_create_urls.rb
@@ -1,4 +1,4 @@
-class CreateUrls < ActiveRecord::Migration
+class CreateUrls < ActiveRecord::Migration[5.2]
   def change
     create_table :urls do |t|
       t.string :url

--- a/bizside_test_app/db/migrate/20211117021329_create_attachment_files.rb
+++ b/bizside_test_app/db/migrate/20211117021329_create_attachment_files.rb
@@ -1,0 +1,9 @@
+class CreateAttachmentFiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :attachment_files do |t|
+      t.string :file, null: false
+      t.string :original_filename
+      t.timestamps
+    end
+  end
+end

--- a/bizside_test_app/db/schema.rb
+++ b/bizside_test_app/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,21 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614071450) do
+ActiveRecord::Schema.define(version: 2021_11_17_021329) do
+
+  create_table "attachment_files", force: :cascade do |t|
+    t.string "file", null: false
+    t.string "original_filename"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "ip_addresses", force: :cascade do |t|
-    t.string   "ip_address_v4"
-    t.string   "ip_address_cidr"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.string   "email_address"
+    t.string "ip_address_v4"
+    t.string "ip_address_cidr"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "urls", force: :cascade do |t|
-    t.string   "url"
-    t.string   "url_without_schema"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.string "url"
+    t.string "url_without_schema"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/bizside_test_app/test/models/attachment_file_test.rb
+++ b/bizside_test_app/test/models/attachment_file_test.rb
@@ -11,13 +11,13 @@ class AttachmentFileTest < ActiveSupport::TestCase
       original_filename: original_filename
     )
 
-    assert_not Bizside.config.storage.ignore_long_filename_error?
+    assert_not Bizside.config.file_uploader.ignore_long_filename_error?
     assert_raise Errno::ENAMETOOLONG do
       af = AttachmentFile.new(file: file)
     end
 
-    Bizside.config.storage['ignore_long_filename_error'] = true
-    assert Bizside.config.storage.ignore_long_filename_error?
+    Bizside.config['file_uploader'] = {'ignore_long_filename_error' => true}
+    assert Bizside.config.file_uploader.ignore_long_filename_error?
     af = AttachmentFile.new(file: file)
     assert af.invalid?
     assert af.errors[:original_filename].any?, 'original_filename で入力エラーが発生していること'

--- a/bizside_test_app/test/models/attachment_file_test.rb
+++ b/bizside_test_app/test/models/attachment_file_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class AttachmentFileTest < ActiveSupport::TestCase
+
+  def test_long_file
+    original_filename = 'あいうえおかきくけこ' * 10 + '.xls'
+
+    file = Rack::Test::UploadedFile.new(
+      Tempfile.new,
+      MimeMagic.by_path(original_filename),
+      original_filename: original_filename
+    )
+
+    assert_not Bizside.config.storage.ignore_long_filename_error?
+    assert_raise Errno::ENAMETOOLONG do
+      af = AttachmentFile.new(file: file)
+    end
+
+    Bizside.config.storage['ignore_long_filename_error'] = true
+    assert Bizside.config.storage.ignore_long_filename_error?
+    af = AttachmentFile.new(file: file)
+    assert af.invalid?
+    assert af.errors[:original_filename].any?, 'original_filename で入力エラーが発生していること'
+  end
+
+end

--- a/lib/bizside/file_uploader.rb
+++ b/lib/bizside/file_uploader.rb
@@ -4,12 +4,7 @@ require_relative 'carrierwave'
 require_relative 'uploader/extension_whitelist'
 require_relative 'uploader/filename_validator'
 require_relative 'uploader/content_type_validator'
-
-if defined?(Rails) && Rails.application.class.parent_name.eql?('BizsideTestApp')
-  # not require 'uploader/exif'
-else
-  require_relative 'uploader/exif'
-end
+require_relative 'uploader/exif'
 
 module Bizside
   # === storage.yml
@@ -43,6 +38,21 @@ module Bizside
 
     def downloaded_file
       Bizside.config.storage.fog? ? downloaded_file_from_fog(file.path) : file.path
+    end
+
+    # ファイル名の長さチェックが可能なように
+    def cache!(new_file = sanitized_file)
+      begin
+        super
+      rescue Errno::ENAMETOOLONG => e
+        if Bizside.config.storage.ignore_long_filename_error?
+          if self.model.respond_to?(:original_filename)
+            self.model.original_filename = filename
+          end
+        else
+          raise e
+        end
+      end
     end
 
     private

--- a/lib/bizside/file_uploader.rb
+++ b/lib/bizside/file_uploader.rb
@@ -45,7 +45,7 @@ module Bizside
       begin
         super
       rescue Errno::ENAMETOOLONG => e
-        if Bizside.config.storage.ignore_long_filename_error?
+        if Bizside.config.file_uploader.ignore_long_filename_error?
           if self.model.respond_to?(:original_filename)
             self.model.original_filename = filename
           end


### PR DESCRIPTION
Bizside.config.storage.ignore_long_filename_error が true の場合には、Errno::ENAMETOOLONG のエラーを抑制するようにしています。

また、対象のモデルがプロパティ original_filename を持っている場合、エラーとなったファイル名を格納するようにしています。

互換性維持のため、Bizside.config.storage.ignore_long_filename_error はデフォルトで false です。
config/aws.yml で明示的に指定する必要があります。