### PR TITLE
job_audit.log 出力に server_address を追加

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 2.0.7
+  * job_audit.log 出力に server_address を追加
+
 ## 2.0.6
   * JobUtils#enqueue_at_with_queue を追加
   * JobUtils#enqueue_at_with_queue_silently を追加

--- a/lib/bizside/resque.rb
+++ b/lib/bizside/resque.rb
@@ -121,6 +121,7 @@ module Resque
         info = {
           time: Time.now.strftime('%Y-%m-%dT%H:%M:%S.%3N%z'),
           add_on_name: Bizside.config.add_on_name,
+          server_address: hostname,
           class: payload['class'],
           args: payload['args'].to_s,
           queue: queue,
@@ -130,6 +131,19 @@ module Resque
           exception_backtrace: Array(exception.backtrace)[0..10].join("\n") # Get only the top 10 because there are many traces.
         }
         info
+      end
+
+      # ホスト名を取得。
+      #
+      # 下記理由から hostname(1) を使用:
+      #
+      # * job 実行環境では環境変数 HOSTNAME がセットされていないケースがある
+      #   (例: 通常の god 起動の場合。他方、container 起動の場合は
+      #   HOSTNAME がセットされている模様)。
+      # * hostname(1) は Linux Standard Base 共通コマンドのため必ず存在する。
+      #   @see https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Common/LSB-Common/rcommands.html
+      def hostname
+        @hostname ||= (`hostname`.chomp rescue '(unknown)')
       end
 
     end

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '2.0.6'
+  VERSION = '2.0.7'
 end


### PR DESCRIPTION
job_audit.log 対応です。

resque worker 名にホスト名が埋め込まれてはいますが、1) chatops に表示されてない。 2) [worker 名にホスト名が埋め込まれているのはあくまで as-is](https://www.rubydoc.info/gems/resque/1.25.0/Resque%2FWorker:to_s) 、の理由から、 job_audit.log に server_address を追加するために、改めて本追加が必要と判断しました。
