### PR TITLE
依存ライブラリのバージョンを更新

### DIFF
--- a/bizside.gemspec
+++ b/bizside.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ltsv', '~> 0.1'
   s.add_runtime_dependency 'mimemagic', '~> 0.3.10'
   s.add_runtime_dependency 'mime-types', '~> 3.1'
-  s.add_runtime_dependency 'rake', '~> 12.3'
+  s.add_runtime_dependency 'rake', '>= 12.3', '< 14.0'
 
   s.add_development_dependency 'RedCloth', '~> 4.2'
   s.add_development_dependency 'capybara', '~> 3.0', '< 3.2'
@@ -43,5 +43,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rails', '>= 5.0.0', '< 6.0.0'
   s.add_development_dependency 'resque', '>= 1.27', '< 3.0.0'
   s.add_development_dependency 'rmagick', '>= 4.2.3', '< 5.0.0'
-  s.add_development_dependency 'sqlite3', '~> 1.3', '< 1.4.0'
+  s.add_development_dependency 'sqlite3', '>= 1.3', '< 1.5.0'
 end

--- a/bizside.gemspec
+++ b/bizside.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake', '>= 12.3', '< 14.0'
 
   s.add_development_dependency 'RedCloth', '~> 4.2'
-  s.add_development_dependency 'capybara', '~> 3.0', '< 3.2'
-  s.add_development_dependency 'cucumber', '>= 2.4', '< 4.0'
+  s.add_development_dependency 'capybara', '~> 3.0', '< 3.36'
+  s.add_development_dependency 'cucumber', '~> 7.1'
   s.add_development_dependency 'cucumber-rails', '~> 1.4'
   s.add_development_dependency 'devise', '>= 3.4.0', '< 5.0.0'
   s.add_development_dependency 'email_validator', '1.5.0'

--- a/bizside_test_app/Gemfile
+++ b/bizside_test_app/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.6'
 
-gem 'bizside', :path => '..'
+gem 'bizside', path: '..'
 gem 'aws-sdk-s3'
 gem 'carrierwave'
 gem 'coffee-rails', '~> 4.2'
@@ -13,7 +13,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'nokogiri'
-gem 'sqlite3', '~> 1.3.6'
+gem 'sqlite3', '>= 1.3', '< 1.5.0'
 gem 'redis', '~> 4.0'
 gem 'request-log-analyzer'
 gem 'resque'
@@ -25,7 +25,7 @@ gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
   gem 'byebug'
-  gem 'cucumber', '~> 3.2'
+  gem 'cucumber'
 end
 
 group :development do


### PR DESCRIPTION
Ruby 2.7 対応が入っているバージョンが使えるように、rake のバージョン制限を緩和しました。
また、合わせて development_dependency と bizside_test_app の Gemfile で指定しているライブラリのバージョンも更新しました。

## runtime_dependency
- rake
  - 13系を許可
  - 13.0.0 で Ruby 2.7 のキーワード引数対応が入っている
    https://github.com/ruby/rake/blob/master/History.rdoc#label-13.0.0
  - Ruby 2.2 のサポートが無くなっているが問題ない

## development_dependency
- sqlite3
  - 1.4系を許可
  - 1.4.2 で Ruby 2.7 の警告の対応が入っている
    https://github.com/sparklemotion/sqlite3-ruby/blob/master/CHANGELOG.rdoc#label-1.4.2
  - 以下の警告が抑制される
    ```
    /opt/hostedtoolcache/Ruby/2.7.3/x64/lib/ruby/gems/2.7.0/gems/activerecord-5.2.7/lib/active_record/connection_adapters/sqlite3_adapter.rb:32: warning: rb_check_safe_obj will be removed in Ruby 3.0
    ```
- capybara
  - Ruby 2.2 のサポートを考慮したバージョン指定になっていたが、
    bizside-ruby は Ruby 2.5 以上が必要なので、 Ruby 2.2 系の考慮は不要
    https://github.com/teamcapybara/capybara/blob/master/History.md#version-320
  - Capybara 3.36.0 以降は Ruby 2.6.0+ が必要なので、それより前のバージョンを使う
    https://github.com/teamcapybara/capybara/blob/master/History.md#version-3360
- cucumber
  - 7系を使う