### PR TITLE
StringUtils.create_random_alpha_string の生成する文字の上限を廃止

### DIFF
--- a/bizside_test_app/test/lib/bizside/string_utils_test.rb
+++ b/bizside_test_app/test/lib/bizside/string_utils_test.rb
@@ -7,4 +7,21 @@ class Bizside::StringUtilsTest < ActiveSupport::TestCase
     assert s =~ /^(?=.*?[a-z])(?=.*?\d).*+$/iu
   end
 
+  def test_create_random_alpha_string_case_sensitive_true
+    s = StringUtils.create_random_alpha_string(10, true)
+    assert s =~ /\A[A-Za-z]{10}\z/
+  end
+
+  def test_create_random_alpha_string_case_sensitive_false
+    s = StringUtils.create_random_alpha_string(10, false)
+    assert s =~ /\A[a-z]{10}\z/
+  end
+
+  def test_create_random_alpha_string_more_than_26_chars
+    s = StringUtils.create_random_alpha_string(53, true)
+    assert s =~ /\A[A-Za-z]{53}\z/
+
+    s = StringUtils.create_random_alpha_string(27, false)
+    assert s =~ /\A[a-z]{27}\z/
+  end
 end

--- a/lib/bizside/string_utils.rb
+++ b/lib/bizside/string_utils.rb
@@ -7,7 +7,9 @@ module Bizside
     def self.create_random_alpha_string length, case_sensitive = false
       chars = ('a'..'z').to_a
       chars += ('A'..'Z').to_a if case_sensitive
-      chars.sample(length).join
+      chars_length = chars.length
+
+      length.times.map { chars[rand(chars_length)] }.join
     end
 
     def self.create_random_string(number)

--- a/lib/bizside/string_utils.rb
+++ b/lib/bizside/string_utils.rb
@@ -9,7 +9,7 @@ module Bizside
       chars += ('A'..'Z').to_a if case_sensitive
       chars_length = chars.length
 
-      length.times.map { chars[rand(chars_length)] }.join
+      Array.new(length) { chars[rand(chars_length)] }.join
     end
 
     def self.create_random_string(number)


### PR DESCRIPTION
* 文字集合から1文字ずつしか使用出来ない、という挙動となっていたため修正前は以下のような制約があった
  * 英小文字の場合: 上限26文字
  * 英大・小文字の場合: 上限52文字