### PR TITLE
faraday version up 0.12 => 1.9.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-## main
+## 2.0.9
   * yes_confirmed? のオプション(fail_on_error)のバグを修正([PR#22](https://github.com/maedadev/bizside-ruby/pull/22))
     * 定義済の変数を参照するように修正
   * StringUtils.create_random_alpha_string の生成する文字の上限を廃止([PR#21](https://github.com/maedadev/bizside-ruby/pull/21))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 2.1.0
+  * faraday version up 0.12 => 1.9.3(#62048)
+
 ## 2.0.9
   * yes_confirmed? のオプション(fail_on_error)のバグを修正([PR#22](https://github.com/maedadev/bizside-ruby/pull/22))
     * 定義済の変数を参照するように修正

--- a/bizside.gemspec
+++ b/bizside.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'carrierwave', '~> 2.2'
   s.add_runtime_dependency 'carrierwave-magic', '~> 0.0.4'
   s.add_runtime_dependency 'fog-aws', '~> 3.0'
-  s.add_runtime_dependency 'faraday', '~> 0.12'
+  s.add_runtime_dependency 'faraday', '~> 1.9.3'
   s.add_runtime_dependency 'ltsv', '~> 0.1'
   s.add_runtime_dependency 'mimemagic', '~> 0.3.10'
   s.add_runtime_dependency 'mime-types', '~> 3.1'

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '2.0.8'
+  VERSION = '2.0.9'
 end

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '2.0.9'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
* gem faraday のアップデート
  * 1系の最新バージョンv1.9.3にする

* すでにmainに他の修正があったのでそれらは別バージョンにわけたいので別コミットにしました。