### PR TITLE
refs #47 Fix for ActiveModel::Error deprecation warnings on Rails 6.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 2.2.1
+  * Validator 関連
+ 
+    * Rails 6.1 の ActiveModel::Error の変更に対応
+
 ## 2.2.0
   * Rails 6.x をサポート
 

--- a/bizside_test_app/app/models/tel_number.rb
+++ b/bizside_test_app/app/models/tel_number.rb
@@ -1,0 +1,6 @@
+# TelValidatorのテスト用モデル
+require 'bizside/validations'
+
+class TelNumber < ApplicationRecord
+  validates :tel, tel: true
+end

--- a/bizside_test_app/app/models/zip_code.rb
+++ b/bizside_test_app/app/models/zip_code.rb
@@ -1,0 +1,6 @@
+# ZipValidatorのテスト用モデル
+require 'bizside/validations'
+
+class ZipCode < ApplicationRecord
+  validates :zip1, zip: { other: :zip2 }
+end

--- a/bizside_test_app/config/locales/ja.yml
+++ b/bizside_test_app/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  errors:
+    messages:
+      invalid: 'は正しくありません。'
+      zip: 'は郵便番号として正しくありません。'

--- a/bizside_test_app/db/migrate/20221214074953_create_tel_number.rb
+++ b/bizside_test_app/db/migrate/20221214074953_create_tel_number.rb
@@ -1,0 +1,9 @@
+class CreateTelNumber < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tel_numbers do |t|
+      t.string :tel
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/bizside_test_app/db/migrate/20221214075024_create_zip_code.rb
+++ b/bizside_test_app/db/migrate/20221214075024_create_zip_code.rb
@@ -1,0 +1,10 @@
+class CreateZipCode < ActiveRecord::Migration[5.2]
+  def change
+    create_table :zip_codes do |t|
+      t.string :zip1
+      t.string :zip2
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/bizside_test_app/db/schema.rb
+++ b/bizside_test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_021329) do
+ActiveRecord::Schema.define(version: 2022_12_14_075024) do
 
   create_table "attachment_files", force: :cascade do |t|
     t.string "file", null: false
@@ -26,9 +26,22 @@ ActiveRecord::Schema.define(version: 2021_11_17_021329) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tel_numbers", force: :cascade do |t|
+    t.string "tel"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "urls", force: :cascade do |t|
     t.string "url"
     t.string "url_without_schema"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "zip_codes", force: :cascade do |t|
+    t.string "zip1"
+    t.string "zip2"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/bizside_test_app/test/models/attachment_file_test.rb
+++ b/bizside_test_app/test/models/attachment_file_test.rb
@@ -32,7 +32,7 @@ class AttachmentFileTest < ActiveSupport::TestCase
     assert Bizside.config.file_uploader.ignore_long_filename_error?
     af = AttachmentFile.new(file: file)
     assert af.invalid?
-    assert af.errors[:original_filename].any?, 'original_filename で入力エラーが発生していること'
+    assert af.errors.include?(:original_filename), 'original_filename で入力エラーが発生していること'
   end
 
 end

--- a/bizside_test_app/test/models/ip_address_test.rb
+++ b/bizside_test_app/test/models/ip_address_test.rb
@@ -106,4 +106,10 @@ class IpAddressTest < ActiveSupport::TestCase
       assert ip_address.invalid?
     end
   end
+
+  def test_エラーメッセージ
+    ip_address = IpAddress.new(ip_address_v4: 'xxx')
+    assert ip_address.invalid?
+    assert_equal ['Ip address v4 はIPアドレスとして正しくありません。'], ip_address.errors.full_messages
+  end
 end

--- a/bizside_test_app/test/models/tel_number_test.rb
+++ b/bizside_test_app/test/models/tel_number_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class TelNumberTest < ActiveSupport::TestCase
+
+  def test_エラーメッセージ
+    tel_number = TelNumber.new(tel: 'xxx')
+    assert tel_number.invalid?
+    assert_equal ['Tel は正しくありません。'], tel_number.errors.full_messages
+  end
+
+end

--- a/bizside_test_app/test/models/url_test.rb
+++ b/bizside_test_app/test/models/url_test.rb
@@ -75,6 +75,20 @@ class UrlTest < ActiveSupport::TestCase
     assert url.valid?
   end
 
+  def test_エラーメッセージ
+    url = Url.new(valid_params.merge(url: 'https://あああ.com'))
+    assert url.invalid?
+    assert_equal ['Url はURLとして正しくありません。'], url.errors.full_messages
+
+    url = Url.new(valid_params.merge(url: 'example.com'))
+    assert url.invalid?
+    assert_equal ['Url は http:// または https:// から始めてください。'], url.errors.full_messages
+
+    url = Url.new(valid_params.merge(url_without_schema: 'https://example.com'))
+    assert url.invalid?
+    assert_equal ['Url without schema は http:// または https:// を含めないでください。'], url.errors.full_messages
+  end
+
   def valid_params
     {
       url: 'http://example.com',

--- a/bizside_test_app/test/models/zip_code_test.rb
+++ b/bizside_test_app/test/models/zip_code_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ZipCodeTest < ActiveSupport::TestCase
+
+  def test_エラーメッセージ
+    zip_code = ZipCode.new(zip1: 'xxx', zip2: 'yyy')
+    assert zip_code.invalid?
+    assert_equal ['Zip1 は郵便番号として正しくありません。'], zip_code.errors.full_messages
+  end
+
+end

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/validations/ip_address_validator.rb
+++ b/validations/ip_address_validator.rb
@@ -16,7 +16,7 @@ class IpAddressValidator < ActiveModel::EachValidator
         raise unless IPAddress::valid_ipv4?(value)
       end
     rescue
-      record.errors[attribute] << (options[:message] || "はIPアドレスとして正しくありません。")
+      record.errors.add(attribute, options[:message] || "はIPアドレスとして正しくありません。")
     end
   end
 end

--- a/validations/tel_validator.rb
+++ b/validations/tel_validator.rb
@@ -14,7 +14,7 @@ class TelValidator < ActiveModel::EachValidator
     return if value.nil? or value.empty?
     
     unless validate_tel(record, value)
-      record.errors[attribute] << I18n.t('errors.messages.invalid')
+      record.errors.add(attribute, I18n.t('errors.messages.invalid'))
     end
   end
   

--- a/validations/url_validator.rb
+++ b/validations/url_validator.rb
@@ -13,17 +13,17 @@ class UrlValidator < ActiveModel::EachValidator
     begin
       URI.parse(value)
     rescue URI::InvalidURIError
-      record.errors[attribute] << (options[:message] || "はURLとして正しくありません。")
+      record.errors.add(attribute, options[:message] || "はURLとして正しくありません。")
       return
     end
     
     if @with_schema
       unless value.start_with?('http://') or value.start_with?('https://')
-        record.errors[attribute] << (options[:message] || "は http:// または https:// から始めてください。")
+        record.errors.add(attribute, options[:message] || "は http:// または https:// から始めてください。")
       end
     else
       if value.start_with?('http://') or value.start_with?('https://')
-        record.errors[attribute] << (options[:message] || "は http:// または https:// を含めないでください。")
+        record.errors.add(attribute, options[:message] || "は http:// または https:// を含めないでください。")
       end
     end
   end

--- a/validations/zip_validator.rb
+++ b/validations/zip_validator.rb
@@ -12,8 +12,7 @@ class ZipValidator < ActiveModel::EachValidator
     return if (zip1.nil? or zip1.empty?) and (zip2.nil? or zip2.empty?)
 
     unless validate_zip(zip1, zip2)
-      record.errors[attribute] << I18n.t('errors.messages.zip')
-      return
+      record.errors.add(attribute, I18n.t('errors.messages.zip'))
     end
   end
 


### PR DESCRIPTION
Fix for deprecation warnings like this

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from ...
```