### PR TITLE
Run CI with both Rails 5 and 6

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -11,6 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: [2.5, 2.6, 2.7]
+        rails-version: [5.2.x, 6.1.x]
+    env:
+      RAILS_VERSION: ${{ matrix.rails-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +25,8 @@ jobs:
       - name: Install gem
         run: bundle exec rake install
       - name: Set up test app
-        run: bundle install -j2
+        run: bundle install -j4
         working-directory: ./bizside_test_app
       - name: Run tests
-        run: bundle exec rake test CONFIG_FILE=bizside_test_app/config/bizside.yml
+        run: rails test CONFIG_FILE=bizside_test_app/config/bizside.yml
+        working-directory: ./bizside_test_app

--- a/bizside_test_app/Gemfile
+++ b/bizside_test_app/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-
-gem 'rails', '~> 5.2.6'
+rails_version = ENV.fetch('RAILS_VERSION', '5.2.x')
+gem 'rails', "~> #{rails_version}"
 
 gem 'bizside', path: '..'
+
 gem 'aws-sdk-s3'
 gem 'carrierwave'
 gem 'coffee-rails', '~> 4.2'
@@ -11,15 +12,16 @@ gem 'fog-aws'
 gem 'ipaddress'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
+gem 'mail', '~> 2.7.1'
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'nokogiri'
-gem 'sqlite3', '>= 1.3', '< 1.5.0'
 gem 'redis', '~> 4.0'
 gem 'request-log-analyzer'
 gem 'resque'
 gem 'resque-scheduler'
 gem 'rmagick'
 gem 'sass-rails', '~> 5.0'
+gem 'sqlite3', '>= 1.3', '< 1.6.0'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 
@@ -34,13 +36,13 @@ group :development do
 end
 
 group :test do
-  gem 'RedCloth'
   gem 'database_cleaner'
   gem 'minitest', '~> 5.15.0'
   gem 'minitest-rails'
   gem 'minitest-reporters'
   gem 'puma'
   gem 'rails-controller-testing'
+  gem 'RedCloth'
   gem 'simplecov'
   gem 'simplecov-rcov'
   gem 'webmock'


### PR DESCRIPTION
This PR adds Rails 6 to the CI matrix.
In addition, the following changes were made.

- Sort gems in alphabetical order
- Replace `bundle exec rake test` with `rails test`
  - Because `bundle install` is already executed.
- Increase the number of parallel jobs for faster CI