### PR TITLE
Add `JobUtils.delayed?`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## master
+  * Bizside::JobUtils
+    * ジョブが遅延しているか判定する `delayed?` を追加
+
 ## 2.3.0
 > **Warning**  
 > **!! BREAKING CHANGE !!**

--- a/lib/bizside/job_utils.rb
+++ b/lib/bizside/job_utils.rb
@@ -99,6 +99,15 @@ module Bizside
       ::Resque.delayed_timestamp_size(timestamp)
     end
 
+    def self.delayed?(klass, *args)
+      if Bizside.rails_env&.test?
+        Rails.logger.info 'テスト時には遅延ジョブは無いものとします。'
+        return false
+      end
+
+      ::Resque.delayed?(klass, *args)
+    end
+
     def self.remove_delayed_in_queue(klass, queue, *args)
       if Bizside.rails_env&.test?
         Rails.logger.info "テスト時には遅延ジョブのキャンセルを行いません。"


### PR DESCRIPTION
This PR adds `JobUtils.delayed?` which calls [Resque.delayed?](https://github.com/resque/resque-scheduler/blob/2e3fb0d0a94a7b2737f4463096287b8aec2447b4/lib/resque/scheduler/delaying_extensions.rb#L275-L282).