### PR TITLE
cron のバリデーションを強化、cron の設定改善

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+## 2.3.7
+* Bizside::CronValidator 
+** バリデーションを強化
+* Bizside::JobUtils
+** add_cron_to と add_cron で cron を設定する際 blocking: true オプションを自動で付与
+
 ## 2.3.6
 * Bizside::LogAnalyzer を削除
 

--- a/bizside_test_app/test/lib/bizside/cron_validator_test.rb
+++ b/bizside_test_app/test/lib/bizside/cron_validator_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Bizside::GengouTest < ActiveSupport::TestCase
+class Bizside::CronValidatorTest < ActiveSupport::TestCase
   
   def test_good
     [
@@ -10,12 +10,13 @@ class Bizside::GengouTest < ActiveSupport::TestCase
       '59 23 31 12 7',
       '0,15 * * * *',
       '0-30 * * * *',
-      '0/120 * * * *',
+      '0/59 * * * *',
       '0,10-20 * * * *',
-      '0,10-20/2 * * * *'
+      '0,10-20/2 * * * *',
+      '* 1,3,5,7,9,11,13,15,17,19,21,23 * * *',
     ].each do |line|
       validator = Bizside::CronValidator.new(line)
-      assert validator.valid?
+      assert validator.valid?, line
     end
   end
   
@@ -25,6 +26,8 @@ class Bizside::GengouTest < ActiveSupport::TestCase
       '60 * * * *',
       '* -1 * * *',
       '* 24 * * *',
+      '* */24 * * *',
+      '* */0 * * *',
       '* * 0 * *',
       '* * 32 * *',
       '* * * 0 *',
@@ -32,10 +35,11 @@ class Bizside::GengouTest < ActiveSupport::TestCase
       '* * * * -1',
       '* * * * 8',
       'a * * * *',
-      ''
+      '',
+      '* 1,3,5,7,9,11,13,15,17,19,21,23,25 * * *',
       ].each do |line|
         validator = Bizside::CronValidator.new(line)
-        assert ! validator.valid?
+        assert ! validator.valid?, line
       end
   end
   

--- a/bizside_test_app/test/lib/bizside/job_utils_test.rb
+++ b/bizside_test_app/test/lib/bizside/job_utils_test.rb
@@ -282,4 +282,15 @@ class Bizside::JobUtilsTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_set_cron_options
+    cronline = "*/59 * * * *"
+    expected = [cronline, { "blocking" => true }]
+    assert_equal expected, JobUtils.set_cron_options(cronline)
+    assert_equal expected, JobUtils.set_cron_options([cronline])
+    assert_equal expected, JobUtils.set_cron_options([cronline, { blocking: true }])
+    assert_equal expected, JobUtils.set_cron_options([cronline, { "blocking" => true }])
+    assert_equal expected, JobUtils.set_cron_options([cronline, { "blocking" => false }])
+  end
+
 end

--- a/lib/bizside/job_utils.rb
+++ b/lib/bizside/job_utils.rb
@@ -173,9 +173,11 @@ module Bizside
       if cronline.to_s.strip.empty?
         return
       elsif CronValidator.new(cronline).valid?
+        new_cron = set_cron_options(cron)
+
         config = {
           :class => job_type,
-          :cron => cron,
+          :cron => new_cron,
           :args => args,
           :persist => true
         }
@@ -403,6 +405,20 @@ module Bizside
       end
     end
     private_class_method :do_perform_and_hooks_instantly
+
+    def self.set_cron_options(cron)
+      ret = Array(cron)
+      if ret.size > 1
+        opts = ret.second
+        opts ||= {}
+        opts = opts.with_indifferent_access
+        opts = opts.merge(blocking: true)
+      else
+        opts = { blocking: true }.with_indifferent_access
+      end
+      ret[1] = opts
+      ret
+    end
 
   end
 end

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '2.3.6'
+  VERSION = '2.3.7'
 end


### PR DESCRIPTION
### cron のバリデーションを強化
[resque-scheduler](https://github.com/resque/resque-scheduler) で内部的に使用されているの [fugit](https://github.com/floraison/fugit) の [仕様変更](https://github.com/floraison/fugit/issues/86) に追随して、スケジューリングできないときは落とすようにしました。
具体的には以下のようにスラッシュ以降の数字が 0 や *、最大値（時間であれば23）を超えないようにしました。
* `* */24 * * *`
* `* */0 * * *`

### cron の設定改善
[rufus-scheduler の blocking オプション](https://github.com/jmettraux/rufus-scheduler?tab=readme-ov-file#blocking-true) を自動で付与するようにしました。