### PR TITLE
authorize_user! returns 403 if request.xhr? == true

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ## main
   * Ruby 2.6 のサポート復活
+  * Bizside::Acl::ControllerHelper
+    * authorize_user! で x-requested-with ヘッダに "XMLHttpRequest" という文字列（大文字小文字区別なし）が含まれていた場合 root_path にリダイレクトではなく 403 を返却
 
 ## 3.0.0
   * Ruby 2.5 のサポート廃止

--- a/lib/bizside/acl/controller_helper.rb
+++ b/lib/bizside/acl/controller_helper.rb
@@ -4,9 +4,12 @@ module Bizside
       include Bizside::Acl::AvailableHelper
 
       def authorize_user!
-        unless available_for(params[:controller], params[:action], params)
+        return if available_for(params[:controller], params[:action], params)
+
+        if request.xhr?
+          head :forbidden
+        else
           redirect_to root_path
-          return
         end
       end
 


### PR DESCRIPTION
In most cases, when ACL rejects a request, it is preferable for asynchronous requests to return a 403 Forbidden status rather than redirecting to the root path.