### PR TITLE
Fix: avoid false duplicate detection in JobUtils.delayed?

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 3.1.9
+  * JobUtilsの遅延ジョブ重複チェックで誤検知する問題を修正
+
 ## 3.1.8
   * ジョブ監査ログのserver_address取得時にSocket.gethostnameを優先するように変更
 

--- a/lib/bizside/job_utils.rb
+++ b/lib/bizside/job_utils.rb
@@ -109,17 +109,26 @@ module Bizside
     end
 
     # Resque.delayed? は @queue の定義がない場合に機能しないため、独自に実装
-    def self.delayed?(klass, args, except: [])
+    def self.delayed?(klass, args, except: [], grace_period: 5.0)
       args_to_check = args.with_indifferent_access.except(*Array(except))
-
-      JobUtils.delayed_queue_peek(0, JobUtils.delayed_queue_schedule_size).each do |timestamp|
-        JobUtils.delayed_timestamp_peek(timestamp, 0, JobUtils.delayed_timestamp_size(timestamp)).each do |job_info|
+      now_f = Time.now.to_f
+  
+      delayed_queue_peek(0, delayed_queue_schedule_size).each do |timestamp|
+        delayed_timestamp_peek(timestamp, 0, delayed_timestamp_size(timestamp)).each do |job_info|
           job_args = job_info['args'].first.presence || {}
           job_args = job_args.with_indifferent_access.except(*Array(except))
-          if job_info['class'] == klass.to_s && job_args == args_to_check
-            Rails.logger.info "遅延ジョブに #{job_info} がすでに登録されています。"
-            return true
+          next unless job_info['class'] == klass.to_s && job_args == args_to_check
+                 
+          # 実行時刻と現在時刻の差が小さければキューイングを試行している自分自身とみなしてスキップ
+          # grace_period以内は実行直前と見なす
+          scheduled_at = timestamp.to_f
+          if (scheduled_at - now_f).abs < grace_period
+            Rails.logger.debug("[delayed?] skip duplicate-check for job scheduled_at=#{scheduled_at}, now=#{now_f}")
+            next
           end
+  
+          Rails.logger.info "遅延ジョブに #{job_info} がすでに登録されています。"
+          return true
         end
       end
 

--- a/lib/bizside/version.rb
+++ b/lib/bizside/version.rb
@@ -1,3 +1,3 @@
 module Bizside
-  VERSION = '3.1.8'
+  VERSION = '3.1.9'
 end


### PR DESCRIPTION
Summary
- Prevent false-positive duplicate detection in JobUtils.delayed? when resque-scheduler
  moves a delayed job to the work queue (scheduler handoff window).

What changed
- delayed? now checks class+args first, and if matched it ignores entries whose delayed
  timestamp is within a short handoff window (default 5s). This avoids treating the
  job that is being moved by the scheduler as a duplicate.

Testing
- Verified on staging with the snapshot rebuild workflow; scheduler handoff no longer blocks jobs.
- Debug log added: "[delayed?] skip duplicate-check for job scheduled_at=..., now=..."

Version
- Bumped to 3.1.9.
